### PR TITLE
Fix for vulnerability GHSA-cxww-7g56-2vh6 reported by GitHub on 2024-09-03

### DIFF
--- a/.github/workflows/_build_package.yml
+++ b/.github/workflows/_build_package.yml
@@ -21,6 +21,6 @@ jobs:
         run: python -m build
       - name: Run twine check
         run: twine check --strict dist/*
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist/*.tar.gz

--- a/.github/workflows/_publish_package.yml
+++ b/.github/workflows/_publish_package.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: ./dist/

--- a/.github/workflows/_publish_package_test.yml
+++ b/.github/workflows/_publish_package_test.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: ./dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ## [Unreleased]
 
 ### Dependencies
+* Updated to upload-artifact@v4  (from upload-artifact@v3)
+* Updated to download-artifact@v4  (from download-artifact@v3)
+
+### Dependencies
 -   updated to ruff==0.4.2  (from ruff==0.3.0)
 -   updated to pyright==1.1.360  (from pyright==1.1.352)
 -   updated to sourcery==1.16  (from sourcery==1.15)


### PR DESCRIPTION
- **Updated to upload-artifact@v4  (from upload-artifact@v3)**
- **Updated to download-artifact@v4  (from download-artifact@v3)**
- **updated CHANGELOG.md**
